### PR TITLE
Fixed a bug where \b gets added to rules that don't need it.

### DIFF
--- a/lex.y
+++ b/lex.y
@@ -123,7 +123,7 @@ name_list
 regex
     : regex_list
         { $$ = $1;
-          if (!(yy.options && yy.options.flex) && $$.match(/[\w\d]$/) && !$$.match(/\\(b|c[A-Z]|x[0-9A-F]{2}|u[a-fA-F0-9]{4}|[0-7]{1,3})$/))
+          if (!(yy.options && yy.options.flex) && $$.match(/[\w\d]$/) && !$$.match(/\\(r|f|n|t|v|s|b|c[A-Z]|x[0-9A-F]{2}|u[a-fA-F0-9]{4}|[0-7]{1,3})$/))
               $$ += "\\b";
         }
     ;

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -301,5 +301,16 @@ exports["test comments"] = function () {
     assert.deepEqual(lex.parse(lexgrammar), expected, "grammar should be parsed correctly");
 };
 
+exports["test rules with trailing escapes"] = function () {
+    var lexgrammar = '%%\n\\#[^\\n]*\\n {/* ok */}\n';
+    var expected = {
+        rules: [
+            ["#[^\\n]*\\n", "/* ok */"],
+        ]
+    };
+
+    assert.deepEqual(lex.parse(lexgrammar), expected, "grammar should be parsed correctly");
+};
+
 if (require.main === module)
     require("test").run(exports);


### PR DESCRIPTION
If rules end with an escape (like \n or \s), \b gets added since the condition for it only requires a trailing letter or digit.
